### PR TITLE
Feat/seongho/1 api details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,16 @@
+buildscript {
+    ext {
+        restdocsApiSpecVersion = '0.17.1'
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
+
+    id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'dev.saintho'
@@ -27,10 +36,40 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation "com.epages:restdocs-api-spec-mockmvc:${restdocsApiSpecVersion}"
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.withType(GenerateSwaggerUI) {
+    dependsOn 'openapi3'
+
+    delete file('src/main/resources/static/docs/')
+    copy {
+        from "build/resources/main/static/docs"
+        into "src/main/resources/static/docs/"
+
+    }
+}
+
+bootJar{
+    dependsOn(':openapi3')
+}
+
+openapi3 {
+    server = 'https://localhost:8080'
+    title = 'voylog server'
+    description = 'voylog api description'
+    version = '0.1.0'
+    outputFileNamePrefix = 'open-api-3.0.1'
+    format = 'json'
+    outputDirectory = 'build/resources/main/static/docs'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ plugins {
     id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
+jar {
+    enabled = false
+}
+
 group = 'dev.saintho'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
@@ -60,12 +64,17 @@ tasks.withType(GenerateSwaggerUI) {
     }
 }
 
-bootJar{
-    dependsOn(':openapi3')
-}
-
 openapi3 {
-    server = 'https://localhost:8080'
+    servers = [
+            {
+                url = 'http://localhost:8080'
+                description = 'local'
+            },
+            {
+                url = 'https://voylog.saintho.dev'
+                description = 'prod'
+            }
+    ]
     title = 'voylog server'
     description = 'voylog api description'
     version = '0.1.0'

--- a/src/main/java/dev/saintho/voylog/config/SecurityConfig.java
+++ b/src/main/java/dev/saintho/voylog/config/SecurityConfig.java
@@ -1,0 +1,20 @@
+package dev.saintho.voylog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.authorizeHttpRequests(authorize ->
+			authorize.anyRequest().permitAll());
+
+		return http.build();
+	}
+}

--- a/src/main/java/dev/saintho/voylog/index/IndexController.java
+++ b/src/main/java/dev/saintho/voylog/index/IndexController.java
@@ -1,0 +1,16 @@
+package dev.saintho.voylog.index;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/index")
+public class IndexController {
+
+	@GetMapping
+	public ResponseEntity<String> hello() {
+		return ResponseEntity.ok("Hello!");
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,8 @@
 
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    url: /docs/open-api-3.0.1.json
+    path: /docs/swagger

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,4 +5,4 @@ springdoc:
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:
     url: /docs/open-api-3.0.1.json
-    path: /docs/swagger
+    path: /swagger-ui

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -6,7 +6,11 @@
     "version" : "0.1.0"
   },
   "servers" : [ {
-    "url" : "https://localhost:8080"
+    "url" : "http://localhost:8080",
+    "description" : "local"
+  }, {
+    "url" : "https://voylog.saintho.dev",
+    "description" : "prod"
   } ],
   "tags" : [ ],
   "paths" : {

--- a/src/main/resources/static/docs/open-api-3.0.1.json
+++ b/src/main/resources/static/docs/open-api-3.0.1.json
@@ -1,0 +1,44 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "voylog server",
+    "description" : "voylog api description",
+    "version" : "0.1.0"
+  },
+  "servers" : [ {
+    "url" : "https://localhost:8080"
+  } ],
+  "tags" : [ ],
+  "paths" : {
+    "/api/v1/index" : {
+      "get" : {
+        "tags" : [ "api" ],
+        "operationId" : "index-docs",
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "text/plain;charset=UTF-8" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/api-v1-index486549215"
+                },
+                "examples" : {
+                  "index-docs" : {
+                    "value" : "Hello!"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "api-v1-index486549215" : {
+        "type" : "object"
+      }
+    }
+  }
+}

--- a/src/test/java/dev/saintho/voylog/index/IndexControllerTest.java
+++ b/src/test/java/dev/saintho/voylog/index/IndexControllerTest.java
@@ -1,0 +1,58 @@
+package dev.saintho.voylog.index;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class})
+@WebMvcTest
+class IndexControllerTest {
+
+	private final MockMvc mockMvc;
+
+	public IndexControllerTest(@Autowired WebApplicationContext ctx,
+		@Autowired RestDocumentationContextProvider contextProvider) {
+
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+			.apply(documentationConfiguration(contextProvider))
+			.addFilters(new CharacterEncodingFilter("UTF-8", true))
+			.alwaysDo(print())
+			.build();
+	}
+
+	@DisplayName("RestDoc Swagger 연동 테스트")
+	@Test
+	void hello() throws Exception {
+
+		mockMvc
+			.perform(
+			RestDocumentationRequestBuilders.get("/api/v1/index"))
+			.andDo(
+				MockMvcRestDocumentationWrapper.document("index-docs",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint())
+				))
+			.andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+}


### PR DESCRIPTION
Backgrounds
-

- #01
- Swagger의 장점을 가져가면서 단점을 극복하기 위해 Spring Rest Docs와 Swagger UI를 연동

Description
-

- Spring Rest Docs와 restdocs-api-spec 플러그인을 이용하여 테스트 결과를 OAS 스펙의 json 파일로 출력
- springdoc을 이용하여 출력된 json 파일을 Swaager UI로 출력

Changes
-

- 194c4f2
- ebeb14a

References
-

- [restdocs-api-spec github](https://github.com/ePages-de/restdocs-api-spec#gradle-plugin-configuration)
- [OpenAPI Specification을 이용한 더욱 효과적인 API 문서화 - 카카오페이 블로그](https://tech.kakaopay.com/post/openapi-documentation/)
- [restdocs + swagger ui 같이사용하기 - thalals 블로그](https://thalals.tistory.com/433)